### PR TITLE
Add Eventbrite links for students/parents and mentors

### DIFF
--- a/next/index.html
+++ b/next/index.html
@@ -50,7 +50,6 @@
 							<div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
 						</form>
             </li>
-
 					</ul>
 					<br/>
           <p><i>Mentors: <a href="https://www.eventbrite.com/e/hack-the-future-15-mentor-tickets-tickets-20980009774">Sign up on Eventbrite</a> to be a mentor for HtF 15 and <a href="/volunteer/">join the volunteer mailing list</a></i></p>

--- a/next/index.html
+++ b/next/index.html
@@ -39,19 +39,21 @@
           <h4>General Assembly San Francisco</h4><p style="margin-top:0;">225 Bush Street, 5th Floor (East Entrance)<br />
           San Francisco, CA 94104</p>
 					<br />
-					<ul>
-						<li>Get emailed when we have more details:<br/>
+          <ul>
+          <li><i>Students:</i> <a href="https://www.eventbrite.com/e/hack-the-future-15-tickets-20979655715">Sign up on Eventbrite</a> before tickets run out
+						<li>Bring a laptop and install some of the <a href="/software.html">software we recommend</a></li>
+            <li>Bring the <a href="/documents/medical.pdf">medical information sheet</a></li>
+						<li>Get emailed when we have updates:<br/>
 							<form action="http://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 
 							<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="width:300px;" required>
 							<div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
 						</form>
             </li>
-						<li>Bring a laptop and install some of the <a href="/software.html">software we recommend</a></li>
-						<li>Bring the <a href="/documents/medical.pdf">medical information sheet</a></li>
+
 					</ul>
 					<br/>
-          <p><i>Mentors: <a href="/volunteer/">Sign up</a> to be a mentor for HtF 15</i></p>
+          <p><i>Mentors: <a href="https://www.eventbrite.com/e/hack-the-future-15-mentor-tickets-tickets-20980009774">Sign up on Eventbrite</a> to be a mentor for HtF 15 and <a href="/volunteer/">join the volunteer mailing list</a></i></p>
           <p><i>Sponsors: if you want to pitch in to help us pay for future HtFs, <a href="/sponsor/">for $100-$300</a> you could help bring technology to kids.</i></p>
 					<br/>
 					<br/>

--- a/next/index.html
+++ b/next/index.html
@@ -34,7 +34,7 @@
 				<img src="/banners/banner_4.png" width="800" height="301" id="anttop" alt="profile image" />
 				<h3>Hack the Future 15</h3><br/>
 				<div class="textlist">
-          <h4>Saturday January 30th, 2016</h4>
+          <h4>Saturday January 30th, 2016 10:00am - 5:00pm</h4>
 					<br />
           <h4>General Assembly San Francisco</h4><p style="margin-top:0;">225 Bush Street, 5th Floor (East Entrance)<br />
           San Francisco, CA 94104</p>


### PR DESCRIPTION
This adds the HtF15 Eventbrite links to hackthefuture.org/next/

For a better flow, I am also moving the announcement mailing list signup back to the fourth item in the student/parent checklist. I had moved it to the top earlier only to fill a hole as parents were awaiting the official announcement.

As evident from the diffs, there's an unfortunate mix of tabs and spaces in this file, but we'll fix those another time.