### PR TITLE
Display Hack the Future 16 info on /next/

### DIFF
--- a/next/index.html
+++ b/next/index.html
@@ -34,8 +34,11 @@
         <img src="/banners/banner_4.png" width="800" height="301" id="anttop" alt="profile image" />
         <h3>Hack the Future 16</h3><br/>
         <div class="textlist">
-          <h4>TBD</h4>
+          <h4>Saturday June 18th, 2016&nbsp;&nbsp; 10:00am - 5:00pm</h4>
           <br />
+          <h4>Pivotal Labs</h4>
+          <p style="margin-top:0;">3495 Deer Creek Road<br />
+          Palo Alto, CA 94304</p>
           <br />
           <ul>
             <li><i>Students:</i> Bring a laptop and install some of the <a href="/software.html">software we recommend</a></li>

--- a/next/index.html
+++ b/next/index.html
@@ -43,7 +43,7 @@
           <ul>
             <li><i>Students:</i> Bring a laptop and install some of the <a href="/software.html">software we recommend</a></li>
             <li>Bring the <a href="/documents/medical.pdf">medical information sheet</a></li>
-            <li>Get emailed when we have a time and place:<br/>
+            <li>Get emailed when registration opens:<br/>
               <form action="http://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 
               <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="width:300px;" required>


### PR DESCRIPTION
We're not yet ready to post the Eventbrite link, but we do have a date and location so we should ensure that http://hackthefuture.org/next/ no longer says "TBD".
