### PR TITLE
Clean up the mentor FAQ and link to it

### DIFF
--- a/next/index.html
+++ b/next/index.html
@@ -49,7 +49,8 @@
             </li>
           </ul>
           <br/>
-          <p><i>Mentors: Join the <a href="/volunteer/">volunteer mailing list</a></i></p>
+          <p><i>Mentors: Join the <a href="/volunteer/">volunteer mailing list</a> and see
+            the <a href="/volunteer/faq.html">mentor faq</a></i></p>
           <p><i>Sponsors: For hosting opportunities, <a href="http://tinyurl.com/htfhero">contact us</a>.
               Or to pitch in to help us pay for future HtFs, <a href="/sponsor/">for $100-$300</a> you could help bring technology to kids.</i></p>
           <br/>

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -56,7 +56,7 @@
         </p><br/>
         <br /><br /><h3>What exactly <i>is</i> Hack the Future?</h3>
         <p class="textlist">
-        It's a recurring day-long hackathon. A hackathon is a technology party. It's freeform and self-directed. We provide power, WiFi, food, chairs, tables, and beanbags, and we let the future hackers hack away on whatever they want. For those who want somewhere to start, there are stations where an open-ended workshop is provided.
+        It's a recurring day-long hackathon. A hackathon is a technology party. It's freeform and self-directed. We provide power, WiFi, food, chairs, and tables, and we let the future hackers hack away on whatever they want. For those who want somewhere to start, there are stations where an open-ended workshop is provided.
         </p>
         <br /><br /><h3>How do we decide what stations are going to be available?</h3>
         <p class="textlist">

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -40,7 +40,10 @@
 
         <h3>I want to help Hack the Future!</h3>
         <p class="textlist">
-        Hack the Future is always looking for qualified mentors. If you have experience kid-wrangling, programming, or both, we'd love to have you join the group. Also, if you work for a company, it would be sweet if you told them how great we are and then asked them for help. We're always looking for partners to help us provide food and t-shirts to the future hackers, and for places to host the next Hack the Future. In particular, we need women technologists to help mentor female future hackers.
+        Hack the Future is always looking for qualified mentors. If you have experience kid-wrangling, programming, or both, we'd love to have you join the group. Also, if you work for a company, it would be sweet if you told them how great we are and then asked them for help. We're always looking for partners to help us provide food and t-shirts to the future hackers, and for places to host the next Hack the Future.
+        </p>
+        <p class="textlist">
+        In particular, we need women technologists to help mentor female future hackers.
         </p>
         <p class="textlist">
         Shape young minds. Meet hackers. Tour museums! Free t-shirt!

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -45,9 +45,6 @@
         <p class="textlist">
         Shape young minds. Meet hackers. Tour museums! Free t-shirt!
         </p>
-        <p class="textlist">
-        And good news for amnesiacs! Free background check.
-        </p>
         <br /><br /><h3>How do I help?</h3>
         <p class="textlist">
         Click here -> <a href="http://groups.google.com/group/htf-volunteers/subscribe">Sign up!</a><br/>
@@ -55,7 +52,7 @@
         </p><br/>
         <br /><br /><h3>What exactly <i>is</i> Hack the Future?</h3>
         <p class="textlist">
-        It's a recurring day-long hackathon. A hackathon is a technology party. It's freeform and self-directed. We provide power, wifi, food, chairs, tables, and beanbags, and we let the future hackers hack away on whatever they want. For those who want somewhere to start, there are stations where an open-ended workshop is provided.
+        It's a recurring day-long hackathon. A hackathon is a technology party. It's freeform and self-directed. We provide power, WiFi, food, chairs, tables, and beanbags, and we let the future hackers hack away on whatever they want. For those who want somewhere to start, there are stations where an open-ended workshop is provided.
         </p>
         <br /><br /><h3>How do we decide what stations are going to be available?</h3>
         <p class="textlist">
@@ -66,7 +63,7 @@
         </p>
         <br /><br /><h3>What if there are costs involved in setting up the station?</h3>
         <p class="textlist">
-        We can't expect the kids/parents to buy stuff by themselves. It needs to be provided. Don't let that discourage you! Your station idea sounds cool already. You should try to find a sponsor, or talk to the group about looking around for partners. We require all the kids bring laptops, but we're trying to stop requiring that.
+        We can't expect the kids/parents to buy stuff by themselves. It needs to be provided. Don't let that discourage you! Your station idea sounds cool already. You should try to find a sponsor, or talk to the group about looking around for partners. We require all the kids bring laptops, and we supply loaner laptops as a backup option.
         </p>
         <br /><br /><h3>I signed up but it sends me too much email.</h3>
         <p class="textlist">

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -59,7 +59,10 @@
         </p>
         <br /><br /><h3>How do we decide what stations are going to be available?</h3>
         <p class="textlist">
-        You can see what stations we've had in the past on our <a href="https://sites.google.com/a/hackthefuture.org/wiki/home/stations-for-htf3">wiki</a>.
+        In the past we've held stations for Unity 3D, Scratch, SketchUp,
+        Minecraft mods, robots, soldering, digital logic, LightUp,
+        3D printing, JavaScript, webpages, Python, Arduino, and
+        Raspberry Pi.
         </p>
         <p class="textlist">
         Ideally a station should be interesting, approachable by someone completely computer-illiterate, very open-ended, and should be something a kid can take home and continue working on independently. But there are no strict rules. Anyone who wants to design and run a station is encouraged to do so. We love variety. Do you have an idea for a station?

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -50,7 +50,8 @@
         </p>
         <br /><br /><h3>How do I help?</h3>
         <p class="textlist">
-        Click here -> <a href="http://groups.google.com/group/htf-volunteers/subscribe">Sign up on htf-volunteers!</a><br/>
+        Click here -> <a href="http://groups.google.com/group/htf-volunteers/subscribe">Sign up</a> on
+        <a href="https://groups.google.com/forum/#!forum/htf-volunteers">htf-volunteers</a>!<br/>
         <small>(and then introduce yourself!)</small>
         </p><br/>
         <br /><br /><h3>What exactly <i>is</i> Hack the Future?</h3>

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -47,7 +47,7 @@
         </p>
         <br /><br /><h3>How do I help?</h3>
         <p class="textlist">
-        Click here -> <a href="http://groups.google.com/group/htf-volunteers/subscribe">Sign up!</a><br/>
+        Click here -> <a href="http://groups.google.com/group/htf-volunteers/subscribe">Sign up on htf-volunteers!</a><br/>
         <small>(and then introduce yourself!)</small>
         </p><br/>
         <br /><br /><h3>What exactly <i>is</i> Hack the Future?</h3>
@@ -67,7 +67,10 @@
         </p>
         <br /><br /><h3>I signed up but it sends me too much email.</h3>
         <p class="textlist">
-        You should subscribe to the mentor announcements mailing list. We only announce in-person meetups and Hack the Future events there.
+        You should subscribe to the mentor announcements MailChimp list. We only send a single announcement for each Hack the Future event.
+        If you then need to catch up on detailed planning discussions, browse
+        the <a href="https://groups.google.com/forum/#!forum/htf-volunteers">htf-volunteers</a>
+        archives from the web.
         </p>
         <p class="textlist">
         <!-- Begin MailChimp Signup Form -->

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -40,13 +40,13 @@
 
         <h3>I want to help Hack the Future!</h3>
         <p class="textlist">
-        Hack the Future is always looking for qualified mentors. If you have experience kid-wrangling, programming, or both, we'd love to have you join the group. Also, if you work for a company, it would be sweet if you told them how great we are and then asked them for help. We're always looking for partners to help us provide food and t-shirts to the future hackers, and for places to host the next Hack the Future.
+        Hack the Future is always looking for qualified mentors. If you have experience kid-wrangling, programming, or both, we'd love to have you join the group. Also, if you work for a company, it would be sweet if you told them how great we are and then asked them for help. We're always looking for partners to help us provide food and T-shirts to the future hackers, and for places to host the next Hack the Future.
         </p>
         <p class="textlist">
         In particular, we need women technologists to help mentor female future hackers.
         </p>
         <p class="textlist">
-        Shape young minds. Meet hackers. Tour museums! Free t-shirt!
+        Shape young minds. Meet hackers. Tour museums! Free T-shirt!
         </p>
         <br /><br /><h3>How do I help?</h3>
         <p class="textlist">
@@ -61,8 +61,8 @@
         <br /><br /><h3>How do we decide what stations are going to be available?</h3>
         <p class="textlist">
         In the past we've held stations for Unity 3D, Scratch, SketchUp,
-        Minecraft mods, robots, soldering, digital logic, LightUp,
-        3D printing, JavaScript, webpages, Python, Arduino, and
+        3D printing, Minecraft mods, robots, soldering, digital logic, LightUp,
+        JavaScript, webpages, Python, Arduino, and
         Raspberry Pi.
         </p>
         <p class="textlist">
@@ -70,7 +70,7 @@
         </p>
         <br /><br /><h3>What if there are costs involved in setting up the station?</h3>
         <p class="textlist">
-        We can't expect the kids/parents to buy stuff by themselves. It needs to be provided. Don't let that discourage you! Your station idea sounds cool already. You should try to find a sponsor, or talk to the group about looking around for partners. We require all the kids bring laptops, and we supply loaner laptops as a backup option.
+        We can't expect the kids/parents to buy stuff by themselves. It needs to be provided. Don't let that discourage you! Your station idea sounds cool already. You should try to find a sponsor, or talk to the group about looking around for partners. We require all the kids bring laptops, and we supply loaner laptops as a backup.
         </p>
         <br /><br /><h3>I signed up but it sends me too much email.</h3>
         <p class="textlist">

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -33,7 +33,7 @@
       <!-- Begin Content -->
       <!-- <div class="section black" id="section5"> -->
         <div class="label" style="padding:25px;text-align:center;">
-          <a href="http://groups.google.com/group/htf-volunteers/subscribe"><img src="/images/signup-button.jpg" /></a>
+          <a href="http://groups.google.com/group/htf-volunteers/subscribe"><img src="/images/signup-button.jpg" width=300 /></a>
         </div>
 
         <div class="label" style="padding:25px;text-align:center;">

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -37,7 +37,7 @@
         </div>
 
         <div class="label" style="padding:25px;text-align:center;">
-          <h1><a href="/volunteer/faq.html">MENTOR FAQ</a></h1><br/>
+          <h1><a href="/volunteer/faq.html" style="color:#09F">MENTOR FAQ</a></h1><br/>
         </div>
 
         <!-- End Content -->


### PR DESCRIPTION
It turns out this page wasn't actually orphaned, just hard to fine because the white link was invisible.

This branch removes any broken links or no longer applicable statements from faq.html, clarifies the two mailing lists (since it was confusing enough for me as a mentor), and makes the FAQ link visible in blue.