### PR TITLE
Add SOFTWARE tab to the Mentor FAQ

### DIFF
--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -24,6 +24,7 @@
           <li><a href="/">HOME</a></li>
           <li><a href="/next">NEXT EVENT</a></li>
           <li><a href="/about">ABOUT</a></li>
+          <li><a href="/software">SOFTWARE</a></li>
           <li><a href="/media">MEDIA</a></li>
           <li><a href="/press">PRESS</a></li>
           <li><a href="/volunteer">VOLUNTEER</a></li>


### PR DESCRIPTION
The last two pull requests independently passed review. One of them added the SOFTWARE tab while the other restored `faq.html` for consumption.

However, I missed the combination of the two! This branch just fixes the orange bar so people won't notice an inconsistency when clicking the MENTOR FAQ link.