### PR TITLE
Display Hack the Future 18 info on /next/

### DIFF
--- a/next/index.html
+++ b/next/index.html
@@ -39,7 +39,7 @@
           <br />
           <h4>South San Francisco Public Library</h4>
           <p style="margin-top:0;">840 West Orange Avenue<br />
-          South San Francisco, CA &nbsp;94080</p>
+          South San Francisco, CA&nbsp; 94080</p>
           <br />
           <p><i>Students:</i></p>
           <ul>

--- a/next/index.html
+++ b/next/index.html
@@ -35,13 +35,17 @@
         <img src="/banners/banner_4.png" width="800" height="301" id="anttop" alt="profile image" />
         <h3>Hack the Future 18</h3><br/>
         <div class="textlist">
-          <h4>TBD</h4>
+          <h4>Saturday April 1st, 2017&nbsp;&nbsp; 10:00am - 5:00pm</h4>
+          <br />
+          <h4>South San Francisco Public Library</h4>
+          <p style="margin-top:0;">840 West Orange Avenue<br />
+          South San Francisco, CA &nbsp;94080</p>
           <br />
           <p><i>Students:</i></p>
           <ul>
             <li>Bring a laptop and install some of the <a href="/software">software we recommend</a></li>
             <li>Bring the <a href="/documents/medical.pdf">medical information sheet</a></li>
-            <li>Get emailed when we have a time and place:<br/>
+            <li>Get emailed when registration opens:<br/>
               <form action="http://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 
               <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="width:300px;" required>


### PR DESCRIPTION
HtF 18 will be on April 1st at the SSF Library.

Although we won't open up the Eventbrite link for about 10 more weeks, get this page ready while courting our potential sponsors.