### PR TITLE
Remove broken Gdrive link for HtF15 photos

### DIFF
--- a/media/index.html
+++ b/media/index.html
@@ -49,9 +49,6 @@
         <h3>Hack the Future 16 Photos</h3>
         <p><a href="https://www.flickr.com/photos/dcbriccetti/sets/72157668997633490">photos on flickr</a></p>
 
-        <h3>Hack the Future 15 Photos</h3>
-        <p><a href="https://drive.google.com/folderview?id=0B3rU73ndGhGQN3pCNmtYblgzRWM&usp=sharing">photos on Google Drive</a></p>
-
         <h3>Hack the Future 12 Photos</h3>
         <p><a href="https://secure.flickr.com/photos/dcbriccetti/albums/72157646532999402">photos on flickr</a></p>
 


### PR DESCRIPTION
I got in touch with Kevin Pai. The photos were migrated as he was running out of space on his Google Drive. He may be able to restore the photos from external media.

The link may change by that time (whether a different Gdrive folder or migrated to flickr), so let's remove the broken link in the meantime.