### PR TITLE
Fix broken link

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -46,7 +46,7 @@
           <p>You may also browse videos and photos from past events on our <a href="/media/">MEDIA</a> page.</p>
 
           <h3>How to Come Prepared</h3>
-          <p>Bring a laptop installed with some of the <a href="/software.html">software we recommend</a>.</p>
+          <p>Bring a laptop installed with some of the <a href="/software">software we recommend</a>.</p>
       </div>
 
         <h3>Wunderkinds</h3>


### PR DESCRIPTION
Looks like I had neglected to fix this when we moved SOFTWARE to its own tab and `/software.html` changed to `/software/index.html`