### PR TITLE
Update SOFTWARE page for Scratch 2.0

### DIFF
--- a/software/index.html
+++ b/software/index.html
@@ -96,10 +96,11 @@
         <h4>Scratch</h4>
         <p>
           Scratch is a simple programming environment from MIT that lets you
-          create interactive games, stories, and animations.
+          create interactive games, stories, and animations. Scratch 2.0 is
+          built on Flash Player which comes bundled with some modern browsers.
         </p>
         <ul>
-          <li><a href="http://scratch.mit.edu/scratch_1.4/">Download Scratch 1.4</a></li>
+          <li><a href="https://www.google.com/chrome/browser/">Download Chrome</a> if not already installed</li>
         </ul>
 
         <h4>Webpages and Javascript</h4>


### PR DESCRIPTION
As this page is used by parties such as the library venue for imaging loaner laptops, it needs to be kept up-to-date.

In particular, the section on Scratch can be updated so that they need not install the old Scratch 1.4