### PR TITLE
Update past event and next event to say HtF21

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,12 +52,11 @@
           <p>See the <a href="/about/">ABOUT</a> page for more information on what to expect at Hack the Future events.</p>
           <p>Hack the Future is a program of <a href="http://learningtech.org">Learningtech.org</a>.</p>
 
-          <h3>Next Event: Hack the Future 20</h3>
-          <p>Hack the Future 20 will be at the SF General Assembly on Dec 2, 2017 from 10:30am to 5:00pm. We hope to see you there!</p>
-          <h4><a href="https://www.eventbrite.com/e/hack-the-future-20-tickets-40059806961">Sign up here!</a></h4>
-          
-          <h3>Past Events: Hack the Future 19</h3>
-          <p>Hack the Future 19 was held at Microsoft on August 26, 2017.
+          <h3>Next Event: Hack the Future 21</h3>
+          <p>Hack the Future 21 will be held at Circuit Launch in Oakland on April 28, 2018 from 10:00am to 5:00pm. We hope to see you there!</p>
+
+          <h3>Past Events: Hack the Future 20</h3>
+          <p>Hack the Future 20 was held at General Assembly SF on Dec 2, 2017.
           We enjoyed seeing you there!</p>
 
           <h3>Future Events</h3>

--- a/next/index.html
+++ b/next/index.html
@@ -33,21 +33,19 @@
           <h2>NEXT EVENT</h2>
         </div>
         <img src="/banners/banner_4.png" width="800" height="301" id="anttop" alt="profile image" />
-        <h3>Hack the Future 20!</h3><br/>
+        <h3>Hack the Future 21</h3><br/>
         <div class="textlist">
-          <h4><a href="https://www.eventbrite.com/e/hack-the-future-20-tickets-40059806961">Sign up here!</a></h4>
+          <h4>April 28, 2018&nbsp;&nbsp;10:00am - 5:00pm</h4>
           <br />
-          <h4>December 2, 2017</h4>
-          <h4>10:30am - 5:00pm</h4>
-          <br />
-          <h4>General Assembly San Francisco</h4><p style="margin-top:0;">225 Bush Street, 5th Floor (East Entrance)<br />
-          San Francisco, CA 94104</p>
+          <h4>Circuit Launch</h4><p style="margin-top:0;">8000 Edgewater Dr Suite #200<br />
+          Oakland, CA 94621</p>
           <br />
           <p><i>Students:</i></p>
           <ul>
             <li>Bring a laptop and install some of the <a href="/software">software we recommend</a></li>
-            <li>Bring the signed <a href="/documents/release_general_assembly.pdf">waiver</a> and <a href="/documents/medical.pdf">medical information sheet</a></li>
-            <li>Get emailed for future events:<br/>
+            <li>Bring the <a href="/documents/medical.pdf">medical information sheet</a></li>
+
+            <li>Get emailed when registration opens:<br/>
               <form action="http://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 
               <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="width:300px;" required>


### PR DESCRIPTION
Update these two pages so that the "Next Event" text doesn't appear five months stale.

We'll have to update this again once the waiver sheet is ready, as well as once the Eventbrite link goes out later, but in the meantime better to clean up the front pages while we're recruiting new volunteers.