### PR TITLE
Software page updates with new stations & downloads

### DIFF
--- a/software/index.html
+++ b/software/index.html
@@ -61,6 +61,17 @@
           <li><a href="http://www.sketchup.com/download">Download SketchUp</a></li>
         </ul>
 
+        <h4>Python</h4>
+        <p>
+          Python comes preinstalled on macOS, but typically without an integrated
+          developer environment (IDE).
+          IDLE is an IDE that comes bundled with Python's main distribution for
+          Windows or macOS.
+        </p>
+        <ul>
+          <li><a href="https://www.python.org/downloads/">Download Python 3</a></li>
+        </ul>
+
         <h4>Greenfoot</h4>
         <p>
           Greenfoot is an interactive Java development environment designed
@@ -74,14 +85,15 @@
 
         <h4>Minecraft Mods</h4>
         <p>
-          Minecraft mods are built using the Forge framework. Both Minecraft and
-          Forge are written in Java and require the Java Development Kit (JDK).
+          Minecraft mods are often built using the Forge framework. Both Minecraft and
+          Forge are written in Java and require Java 8 (will not work
+          with Java 9 nor 10).
           You should also install an IDE.
         </p>
         <ul>
-          <li><a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">Download Java JDK</a></li>
+          <li><a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">Download Java JDK 8</a></li>
           <li><a href="https://www.jetbrains.com/idea/#chooseYourEdition">Download IntelliJ IDEA</a> Community Edition</li>
-          <li><a href="https://github.com/hackthefuture/station-minecraft-mod">Read the Minecraft station github page</a> to set up your Forge environment
+          <li><a href="https://github.com/hackthefuture/station-minecraft-mod">Read the Minecraft station GitHub page</a>
         </ul>
 
         <h4>Arduino</h4>
@@ -97,10 +109,27 @@
         <h4>Raspberry Pi</h4>
         <p>
           Raspberry Pi is a series of single-board computers designed for teaching
-          software and hardware from the ground up. Linux and macOS are all set up to
-          interface with a Pi, while Windows benefits from additional terminal software.
+          software and hardware from the ground up. Linux and macOS are set up to
+          interface with a Pi, while Windows benefits from terminal software.
+          Minecraft: Pi Edition is a version of Minecraft developed for educational
+          purposes which can be controlled via the <tt>mcpi</tt> package for Python 2.
         </p>
         <ul>
+          <li><a href="http://www.putty.org/">Download PuTTY</a> for Windows</li>
+          <li><a href="https://www.python.org/downloads/release/python-2715/">Download Python 2</a></li>
+          <li><a href="https://github.com/hackthefuture/station-raspberry-pi">Read the Raspberry Pi station GitHub page</a>
+        </ul>
+
+        <h4>micro:bit</h4>
+        <p>
+          The BBC micro:bit is a microcontroller board that comes with web-based block
+          programming, MicroPython, built-in accelerometers, Bluetooth support, and
+          other "batteries included". PuTTY or other terminal software is helpful for
+          MicroPython, while block-based programming can be done entirely in the browser.
+        </p>
+        <ul>
+          <li><a href="https://www.google.com/chrome/browser/">Download Chrome</a> if not already installed</li>
+          <li><a href="https://os.mbed.com/handbook/Windows-serial-configuration">Download the serial port driver</a> for Windows</li>
           <li><a href="http://www.putty.org/">Download PuTTY</a> for Windows</li>
         </ul>
 
@@ -118,17 +147,14 @@
 
         <h4>Webpages and JavaScript</h4>
         <p>
-          If your goal is to create a webpage or a JavaScript game that you can
-          play in the browser, that will probably require the least amount of
-          software installation. A text editor and a browser are all you need,
-          and you likely have those on your computer already.
+          If your goal is to create a webpage or a JavaScript game, a text editor
+          and a browser are all you need to get started.
         </p>
         <ul>
           <li><a href="https://www.google.com/chrome/browser/">Download Chrome</a> if not already installed</li>
           <li><a href="http://notepad-plus-plus.org/download/">Download
             Notepad++</a> for Windows, or Xcode from the Mac App Store</li>
-          <li><a href="http://hackthefuture.org/projects/">Download
-          our examples</a> that you can hack</li>
+          <li><a href="http://hackthefuture.org/projects/">Read our examples</a> that you can hack</li>
         </ul>
 
       </div>


### PR DESCRIPTION
With some learnings from HtF 22, here I've added links for Python and micro:bit plus clarified download links for Minecraft and Raspberry Pi.

The old text on webpages/JavaScript started looking a bit odd by itself with a paragraph about minimal software installation. After all we now have Scratch, micro:bit, and other stations that are browser-based, so I trimmed the text down.