### PR TITLE
Fix missing YouTube videos and "not fully secure" warning

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "httpss://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="httpss://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>
     <link rel="stylesheet" type="text/css" href="css/simple.css" />
-    <link href="http://cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css" />
+    <link href="https://cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css" />
   </head>
   <body>
     <div id="fb-root"></div>
@@ -42,7 +42,7 @@
       <!-- Begin Content -->
       <div class="section black" id="section1">
         <div class="video" >
-          <iframe width="721" height="440" src="http://www.youtube.com/embed/ox3xHMYFcSE?wmode=transparent&amp;rel=0" frameborder="0" allowfullscreen></iframe>
+          <iframe width="721" height="440" src="https://www.youtube.com/embed/ox3xHMYFcSE?wmode=transparent&amp;rel=0" frameborder="0" allowfullscreen></iframe>
         </div>
         <div class="textlist">
           <h3>Hack the Future</h3>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "httpss://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="httpss://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>

--- a/media/index.html
+++ b/media/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>

--- a/next/index.html
+++ b/next/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>

--- a/press/index.html
+++ b/press/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>
@@ -42,7 +42,7 @@
         <a href="http://articles.sfgate.com/2011-08-21/bay-area/29911056_1_video-games-war-games-young-hackers">Read</a> SF Chronicle's article about Hack the Future 2 online.</p>
         <h3>KQED</h3>
         <p class="textlist">
-        <a href="http://www.youtube.com/watch?feature=player_embedded&v=4fBXVtIztBc">Watch</a> this PBS video about Al Alcorn. He's famous, so his being at Hack the Future got us into the video.
+        <a href="https://www.youtube.com/watch?feature=player_embedded&v=4fBXVtIztBc">Watch</a> this PBS video about Al Alcorn. He's famous, so his being at Hack the Future got us into the video.
         </p>
       </div>
       <!-- End Content -->

--- a/software/index.html
+++ b/software/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Software Downloads - Hack the Future</title>

--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>
@@ -82,10 +82,10 @@
         </p>
         <p class="textlist">
         <!-- Begin MailChimp Signup Form -->
-        <link href="http://cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
+        <link href="https://cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
 
         <div id="mc_embed_signup">
-          <form action="http://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=f1dd97914b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
+          <form action="https://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=f1dd97914b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 
             <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="dont_send_me_much@email.very_busy" required>
             <div class="clear"><input type="submit" value="Hear about meetups only" name="subscribe" id="mc-embedded-subscribe" class="button"></div>

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>

--- a/volunteer/signup.html
+++ b/volunteer/signup.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <title>Hack the Future</title>
@@ -47,10 +47,10 @@
         <h3>I love mailing lists.</h3>
         <p>Subscribe here to get email about upcoming events</p>
         <!-- Begin MailChimp Signup Form -->
-        <link href="http://cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
+        <link href="https://cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
 
         <div id="mc_embed_signup">
-          <form action="http://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
+          <form action="https://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 
 
             <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>


### PR DESCRIPTION
GitHub added support for https on domains like ours just a few months ago: https://blog.github.com/2018-05-01-github-pages-custom-domains-https/

I was able to enable this by checking a box and left things to settle over a couple days. However, it turns out this is what made the YouTube frames disappear. Moreover, Chrome complains about remaining insecure elements, possibly the old MailChimp http reference.

As for old links to http://learningtech.org, Google Groups, or even http://hackthefuture.org, for now these be fine as they automatically redirect to https.