### PR TITLE
Link to SuperHappyDevHouse Wikipedia page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -55,7 +55,7 @@
         For Willie Yee, 12, the event is like Christmas in May; it's the reason he signed up so quickly. "I like programming," says the San Jose 7th grader. "But I really want to learn more complex commands for some programming languages."
         <img src="/images/about_1.jpg" width="250" height="188" alt="profile image" style="float: left; margin:25px 10px 0 0;" />
         <br /><br />
-        Hack the Future is fashioned on SuperHappyDevHouse, where the wunderkinds who fancy creation over computer cracking talk tech, swap blue-sky ideas and collaborate to come up with "the next big thing." Hack the Future is a one-day party and hackathon for youth in grades 5-12, to show them what it's like to be a hacker and see if it's for them.
+        Hack the Future is fashioned on <a href="https://en.wikipedia.org/wiki/SuperHappyDevHouse">SuperHappyDevHouse</a>, where the wunderkinds who fancy creation over computer cracking talk tech, swap blue-sky ideas and collaborate to come up with "the next big thing." Hack the Future is a one-day party and hackathon for youth in grades 5-12, to show them what it's like to be a hacker and see if it's for them.
         <br /><br />
         The mentors don't tell students what to do, but provide a variety of starting points and suggestions for how the students can direct their own learning in technology. Students are free to work on whatever they want. Mentors keep students from getting stuck, and show the way forward when they can't find it.
         <img src="/images/about_2.jpg" width="250" height="188" alt="profile image" style="float: left; margin:25px 10px 0 0;" />


### PR DESCRIPTION
The SHDH Wikipedia article does a great job outlining the history and mirroring Hack the Future's mission.

Hopefully the zealous editors won't ever remove it (as they did David Weekly's bio), but if that happens we'll just adapt by unlinking here.