### PR TITLE
Fix "not fully secure" warning on /next/

### DIFF
--- a/next/index.html
+++ b/next/index.html
@@ -50,7 +50,7 @@
             <li>Bring a laptop and install some of the <a href="/software">software we recommend</a></li>
             <li>Bring the <a href="/documents/medical.pdf">medical information sheet</a></li>
             <li>Get emailed when registration opens:<br/>
-              <form action="http://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
+              <form action="https://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 
               <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="width:300px;" required>
               <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>


### PR DESCRIPTION
Minor followup from #68 to clean up the other page with the same issue.