### PR TITLE
Add signup and waiver links for HtF24

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,9 +52,8 @@
           <p>See the <a href="/about/">ABOUT</a> page for more information on what to expect at Hack the Future events.</p>
           <p>Hack the Future is a program of <a href="http://learningtech.org">Learningtech.org</a>.</p>
 
-          <h3>Past Events: Hack the Future 23</h3>
-          <p>Hack the Future 23 was held at the Lafayette Library &amp; Learning Center on February 23, 2019.
-          We enjoyed seeing you there!</p>
+          <h3>Next Event: Hack the Future 24</h3>
+          <p>Hack the Future 24 will be held at Microsoft in Sunnyvale on June 22, 2019 from 10:00 AM to 5:00 PM. We hope to see you there!</p>
 
           <h3>Future Events</h3>
           <p>If you know of a place that could host a future event,

--- a/next/index.html
+++ b/next/index.html
@@ -33,14 +33,26 @@
           <h2>NEXT EVENT</h2>
         </div>
         <img src="/banners/banner_4.png" width="800" height="301" id="anttop" alt="profile image" />
-        <h3>Hack the Future 24</h3><br/>
+        <h3>Hack the Future 24 - Microsoft Sunnyvale</h3><br/>
         <div class="textlist">
-          <h4>Hack the Future 24 will be at Microsoft's Sunnyvale campus on Saturday, June 22, 2019 from 10AM to 5PM.</h4>
+          <p>
+            <h4><a href="https://htf24.eventbrite.com/">Sign up here!</a></h4>
+            <h4>DATE AND TIME</h4>
+            <p>Saturday, June 22, 2019<br/>
+               10:30 AM - 5:00 PM PDT
+            </p>
+            <h4>LOCATION</h4>
+            <p>Microsoft Sunnyvale<br />
+               1020 Enterprise Way<br />
+               Sunnyvale, California 94089<br/>
+               <a href="https://goo.gl/maps/MUia4feG36D2">map</a>
+            </p>
+          </p>
           <br />
           <p><i>Students:</i></p>
           <ul>
             <li>Bring a laptop and install some of the <a href="/software">software we recommend</a></li>
-            <li>Bring the <a href="/documents/medical.pdf">medical information sheet</a></li>
+            <li>Bring the signed <a href="/documents/release_microsoft.pdf">waiver</a> and <a href="/documents/medical.pdf">medical information sheet</a></li>
             <li>Get emailed for future events:<br/>
               <form action="https://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 


### PR DESCRIPTION
This basically restores much of the text we had when Joe and Dawn set up HtF22 at Microsoft.

* [ ] Check that Eventbrite link has gone live then merge this