### PR TITLE
Add trailing slashes to avoid extra redirects

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -17,13 +17,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->
@@ -47,7 +47,7 @@
           <p>You may also browse videos and photos from past events on our <a href="/media/">MEDIA</a> page.</p>
 
           <h3>How to Come Prepared</h3>
-          <p>Bring a laptop installed with some of the <a href="/software">software we recommend</a>.</p>
+          <p>Bring a laptop installed with some of the <a href="/software/">software we recommend</a>.</p>
       </div>
 
         <h3>Wunderkinds</h3>

--- a/index.html
+++ b/index.html
@@ -29,13 +29,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->
@@ -71,7 +71,7 @@
           </div>
 
           <h3>Software</h3>
-          <p><a href="/software">Here</a> is a link to station information and software downloads to come prepared.</p>
+          <p><a href="/software/">Here</a> is a link to station information and software downloads to come prepared.</p>
 
         </div>
       </div>

--- a/media/index.html
+++ b/media/index.html
@@ -18,13 +18,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->

--- a/next/index.html
+++ b/next/index.html
@@ -17,13 +17,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->
@@ -51,7 +51,7 @@
           <br />
           <p><i>Students:</i></p>
           <ul>
-            <li>Bring a laptop and install some of the <a href="/software">software we recommend</a></li>
+            <li>Bring a laptop and install some of the <a href="/software/">software we recommend</a></li>
             <li>Bring the signed <a href="/documents/release_microsoft.pdf">waiver</a> and <a href="/documents/medical.pdf">medical information sheet</a></li>
             <li>Get emailed for future events:<br/>
               <form action="https://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">

--- a/press/index.html
+++ b/press/index.html
@@ -17,13 +17,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->

--- a/projects/index.html
+++ b/projects/index.html
@@ -10,8 +10,8 @@
            <li><a href="https://www.khanacademy.org/computing/computer-programming/programming">Learn JavaScript</a> on Khan Academy;
                start with the introductory videos
                or <a href="https://www.khanacademy.org/computing/computer-programming/programming/drawing-basics/p/challenge-funny-face">code a funny face</a> when you're ready</li><br/>
-           <li><a href="/projects/chess">Chess</a> <a href="/projects/chess/editor.html">(or edit online!)</a></li>
-           <li><a href="/projects/pong">Pong</a> <a href="/projects/pong/editor.html">(or edit online!)</a></li>
+           <li><a href="/projects/chess/">Chess</a> <a href="/projects/chess/editor.html">(or edit online!)</a></li>
+           <li><a href="/projects/pong/">Pong</a> <a href="/projects/pong/editor.html">(or edit online!)</a></li>
            <li><a href="https://raw.githubusercontent.com/velveteenrobot/hack_the_future_turtlebot/master/turtlebot_teleop.html">Turtlebot</a></li><br/>
            <li>Or <a href="https://www.khanacademy.org/computing/computer-programming/html-css">make a website</a> with HTML, CSS, and/or JavaScript!</li>
         </ul>

--- a/software/index.html
+++ b/software/index.html
@@ -18,13 +18,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->

--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -17,13 +17,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -22,13 +22,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -21,13 +21,13 @@
       <div id="navigation">
         <ul class="navigation">
           <li><a href="/">HOME</a></li>
-          <li><a href="/next">NEXT EVENT</a></li>
-          <li><a href="/about">ABOUT</a></li>
-          <li><a href="/software">SOFTWARE</a></li>
-          <li><a href="/media">MEDIA</a></li>
-          <li><a href="/press">PRESS</a></li>
-          <li><a href="/volunteer">VOLUNTEER</a></li>
-          <li><a href="/sponsor">SPONSOR</a></li>
+          <li><a href="/next/">NEXT EVENT</a></li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/software/">SOFTWARE</a></li>
+          <li><a href="/media/">MEDIA</a></li>
+          <li><a href="/press/">PRESS</a></li>
+          <li><a href="/volunteer/">VOLUNTEER</a></li>
+          <li><a href="/sponsor/">SPONSOR</a></li>
         </ul>
       </div>
       <!-- End Naviagtion -->


### PR DESCRIPTION
Some time ago when I was testing certificates for our transition to HTTPS, I noticed that each URL without a trailing slash resulted in an extra redirect under the hood.

To correct this, going forward any URL to a folder name should end in a trailing slash for consistency.