### PR TITLE
Remove broken link to Khan Academy funny face lesson

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -7,9 +7,7 @@
         <h4>Here are some projects you can hack on</h4>
         To download and play with a game, right-click it and choose "save target as." Once you've downloaded it, you can simply open it in a browser to play, but the real fun happens when you open it with an editor like notepad or textedit. Then you can see the code that makes the game happen, and you can change how the game works!<br/>
         <ul>
-           <li><a href="https://www.khanacademy.org/computing/computer-programming/programming">Learn JavaScript</a> on Khan Academy;
-               start with the introductory videos
-               or <a href="https://www.khanacademy.org/computing/computer-programming/programming/drawing-basics/p/challenge-funny-face">code a funny face</a> when you're ready</li><br/>
+           <li><a href="https://www.khanacademy.org/computing/computer-programming/programming">Learn JavaScript</a> on Khan Academy</li></br>
            <li><a href="/projects/chess/">Chess</a> <a href="/projects/chess/editor.html">(or edit online!)</a></li>
            <li><a href="/projects/pong/">Pong</a> <a href="/projects/pong/editor.html">(or edit online!)</a></li>
            <li><a href="https://raw.githubusercontent.com/velveteenrobot/hack_the_future_turtlebot/master/turtlebot_teleop.html">Turtlebot</a></li><br/>


### PR DESCRIPTION
We could update the `/challenge-funny-face` link, but it seems a bit out of place to focus deep on the part tied to ProcessingJS.

Better to just link to the top-level Khan Academy tutorial, which includes drawing but also concepts like variables and loops.