### PR TITLE
Fix Twitter hashtag

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       fjs.parentNode.insertBefore(js, fjs);
       }(document, 'script', 'facebook-jssdk'));</script>
     <div class="fb-like" style="position:absolute;" data-href="http://hackthefuture.org" data-send="false" data-layout="button_count" data-width="450" data-show-faces="false"></div>
-    <div style="position:absolute;top:25px;"><a href="//twitter.com/share" class="twitter-share-button" style="position:absolute;top:500px;" data-url="http://hackthefuture.org" data-text="Check out Hack the Future!" data-hashtags="htf">Tweet</a></div>
+    <div style="position:absolute;top:25px;"><a href="//twitter.com/share" class="twitter-share-button" style="position:absolute;top:500px;" data-url="http://hackthefuture.org" data-text="Check out Hack the Future!" data-hashtags="kidsHtF">Tweet</a></div>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     <!-- Begin Wrapper -->
     <div id="wrapper">


### PR DESCRIPTION
If you click the little icon in the top left it should default to #kidsHtF, not #htf. Thanks @Hum4n01d for catching.