### PR TITLE
Add HtF25 registration link

### DIFF
--- a/next/index.html
+++ b/next/index.html
@@ -35,6 +35,7 @@
         <img src="/banners/banner_4.png" width="800" height="301" id="anttop" alt="profile image" />
         <h3>Hack the Future 25</h3><br/>
         <div class="textlist">
+          <h3><a href="https://htf25.eventbrite.com/">Sign up here!</a></h3><br/>
           <h4>DATE AND TIME</h4>
           <p>Saturday, February 22, 2020<br/>
              10:00 AM &ndash; 5:00 PM PDT
@@ -49,8 +50,8 @@
           <p><i>Students:</i></p>
           <ul>
             <li>Bring a laptop and install some of the <a href="/software/">software we recommend</a></li>
-            <li>Bring the signed <a href="/documents/medical.pdf">medical information sheet</a></li>
-            <li>Get emailed when registration opens:<br/>
+            <li>Bring the signed <a href="/documents/release_thetech.pdf">waiver</a> and <a href="/documents/medical.pdf">medical information sheet</a></li>
+            <li>Get emailed for future events:<br/>
               <form action="https://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 
               <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="width:300px;" required>


### PR DESCRIPTION
We opened up Eventbrite registration last night so update the /next/ page accordingly. Local test:

![image](https://user-images.githubusercontent.com/1616866/74539093-4a128000-4ef2-11ea-94b8-7f0814bf3d0c.png)