### PR TITLE
Mark HtF25 done

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,9 +52,9 @@
           <p>See the <a href="/about/">ABOUT</a> page for more information on what to expect at Hack the Future events.</p>
           <p>Hack the Future is a program of <a href="http://learningtech.org">Learningtech.org</a>.</p>
 
-          <h3>Next Event: Hack the Future 25</h3>
-          <p>Hack the Future 25 will be held at The Tech Interactive in San Jose on February 22, 2020 from 10:00 AM to 5:00 PM.
-             We hope to see you there!</p>
+          <h3>Past Events: Hack the Future 25</h3>
+          <p>Hack the Future 25 was held at The Tech Interactive on February 22, 2020.
+          We enjoyed seeing you there!</p>
 
           <h3>Future Events</h3>
           <p>If you know of a place that could host a future event,

--- a/next/index.html
+++ b/next/index.html
@@ -33,24 +33,15 @@
           <h2>NEXT EVENT</h2>
         </div>
         <img src="/banners/banner_4.png" width="800" height="301" id="anttop" alt="profile image" />
-        <h3>Hack the Future 25</h3><br/>
+        <h3>Hack the Future 26</h3><br/>
         <div class="textlist">
-          <h3><a href="https://htf25.eventbrite.com/">Sign up here!</a></h3><br/>
-          <h4>DATE AND TIME</h4>
-          <p>Saturday, February 22, 2020<br/>
-             10:00 AM &ndash; 5:00 PM PDT
-          </p>
-          <h4>LOCATION</h4>
-          <p>The Tech Interactive<br/>
-             201 S Market St<br/>
-             San Jose, California 95113<br/>
-          </p>
+          <h4>TBD</h4>
           <br/>
 
           <p><i>Students:</i></p>
           <ul>
             <li>Bring a laptop and install some of the <a href="/software/">software we recommend</a></li>
-            <li>Bring the signed <a href="/documents/release_thetech.pdf">waiver</a> and <a href="/documents/medical.pdf">medical information sheet</a></li>
+            <li>Bring the <a href="/documents/medical.pdf">medical information sheet</a></li>
             <li>Get emailed for future events:<br/>
               <form action="https://hackthefuture.us2.list-manage.com/subscribe/post?u=93392dc3a05ea1cfc8557a575&amp;id=6754f69cb6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 


### PR DESCRIPTION
and refer to HtF26 on the /next/ page. This is somewhat overdue.

I tested these changes locally with macOS's built-in Apache httpd.