### PR TITLE
Update copyright footers to 2025 and notes about recent website fixes

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -68,7 +68,7 @@
       <!-- End Content -->
         <!-- Begin Footer -->
         <div class="footer">
-          <p>&copy; 2011&ndash;2021 Hack the Future</p>
+          <p>&copy; 2011&ndash;2025 Hack the Future</p>
         </div>
         <!-- End Footer -->
     </div>

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
       <!-- End Content -->
       <!-- Begin Footer -->
       <div class="footer">
-        <p>&copy; 2011&ndash;2021 Hack the Future</p>
+        <p>&copy; 2011&ndash;2025 Hack the Future</p>
         <!-- End Footer -->
       </div>
     </div>

--- a/media/index.html
+++ b/media/index.html
@@ -173,7 +173,7 @@
       <!-- End Content -->
       <!-- Begin Footer -->
       <div class="footer">
-        <p>&copy; 2011&ndash;2021 Hack the Future</p>
+        <p>&copy; 2011&ndash;2025 Hack the Future</p>
         <!-- End Footer -->
       </div>
     </div>

--- a/next/index.html
+++ b/next/index.html
@@ -72,7 +72,7 @@
       </div>
         <!-- Begin Footer -->
         <div class="footer">
-          <p>&copy; 2011&ndash;2021 Hack the Future</p>
+          <p>&copy; 2011&ndash;2025 Hack the Future</p>
         </div>
         <!-- End Footer -->
     <!-- End Wrapper -->

--- a/press/index.html
+++ b/press/index.html
@@ -48,7 +48,7 @@
       <!-- End Content -->
         <!-- Begin Footer -->
         <div class="footer">
-          <p>&copy; 2011&ndash;2021 Hack the Future</p>
+          <p>&copy; 2011&ndash;2025 Hack the Future</p>
         </div>
         <!-- End Footer -->
     </div>

--- a/software/index.html
+++ b/software/index.html
@@ -178,7 +178,7 @@
       </div>
         <!-- Begin Footer -->
         <div class="footer">
-          <p>&copy; 2011&ndash;2021 Hack the Future</p>
+          <p>&copy; 2011&ndash;2025 Hack the Future</p>
         </div>
         <!-- End Footer -->
     </div>

--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -69,7 +69,7 @@
       <!-- End Content -->
         <!-- Begin Footer -->
         <div class="footer">
-          <p>&copy; 2011&ndash;2021 Hack the Future</p>
+          <p>&copy; 2011&ndash;2025 Hack the Future</p>
         </div>
         <!-- End Footer -->
       </div>

--- a/volunteer/faq.html
+++ b/volunteer/faq.html
@@ -97,7 +97,7 @@
         <!-- End Content -->
         <!-- Begin Footer -->
         <div class="footer">
-          <p>&copy; 2011&ndash;2021 Hack the Future</p>
+          <p>&copy; 2011&ndash;2025 Hack the Future</p>
           <!-- End Footer -->
         </div>
       </div>

--- a/volunteer/index.html
+++ b/volunteer/index.html
@@ -44,7 +44,7 @@
         <!-- End Content -->
         <!-- Begin Footer -->
         <div class="footer">
-          <p>&copy; 2011&ndash;2021 Hack the Future</p>
+          <p>&copy; 2011&ndash;2025 Hack the Future</p>
         </div>
         <!-- End Footer -->
       </div>

--- a/volunteer/signup.html
+++ b/volunteer/signup.html
@@ -63,7 +63,7 @@
       <!-- End Content -->
       <!-- Begin Footer -->
       <div class="footer">
-        <p>&copy; 2011&ndash;2021 Hack the Future</p>
+        <p>&copy; 2011&ndash;2025 Hack the Future</p>
         <!-- End Footer -->
       </div>
     </div>


### PR DESCRIPTION
Up until last week the site had rotted giving "this site is insecure" errors. I'm not sure how long it had been that way. This PR tops of those changes with updating the hardcoded year to 2025, but first some notes on the troubleshooting and cleanup:
* The main issue was that GitHub deprecated its *.github.com user sites back in 2013, but actually broke it in 2021: https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/ and we had never the cleanup, so I had to update the DNS records accordingly
* Also renamed the repo from `hackthefuture.github.com` to `hackthefuture.github.io` for clarity
* Added IPv6 support
* One of the GitHub Pages UI fields--I'm not sure which--resulted in this commit to set CNAME: 4c13fc7726d3d90573281a71ba5b1db10dd6ecf7
* Also renamed the main branch from `master` to `main`, getting with the times from 2020: https://github.com/github/renaming
* Then had to click this button on GitHub pages again:
<img width="783" height="86" alt="image" src="https://github.com/user-attachments/assets/72bde69f-1f4a-4051-9adc-292dc71bcf02" />

And then after a little waiting, https://hackthefuture.org got back to rendering once again without SSL errors.

And some final cleanup: this PR updates the copyright year that got 4 years stale via sed `'s/2021 Hack the/2025 Hack the/'`, same as we did in #67 #81 #85. In two weeks it'll be stale again, so I'm putting it on myself by January 1st to either do this one more time, or finally put in the JavaScript to use the year from the user's browser.
